### PR TITLE
Use go modules cache

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -21,27 +21,44 @@ commands:
           from: << parameters.filename >>
           to: << parameters.bucket >>
           arguments: '--acl public-read --cache-control no-cache'
+
+aliases:
+- &restore_cache
+  restore_cache:
+    key: go-mod-v1-{{ checksum "go.sum" }}
+- &save_cache
+  save_cache:
+    key: go-mod-v1-{{ checksum "go.sum" }}
+    paths:
+    - "/go/pkg/mod"
+
 jobs:
   lint:
     executor:
       name: default
     steps:
       - checkout
+      - *restore_cache
       - run: make check-style
+      - *save_cache
 
   test:
     executor:
       name: default
     steps:
       - checkout
+      - *restore_cache
       - run: make test
+      - *save_cache
 
   build:
     executor:
       name: default
     steps:
       - checkout
+      - *restore_cache
       - run: make dist
+      - *save_cache
       - persist_to_workspace:
           root: dist
           paths:


### PR DESCRIPTION
This should speed up the build a bit.

Taken from https://circleci.com/blog/go-v1.11-modules-and-circleci/ and https://github.com/mattermost/mattermost-cloud/blob/master/.circleci/config.yml#L7-L15