### PR TITLE
[MM-19848] Extract min required server version in release notes

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -107,13 +107,12 @@ jobs:
       - run:
           name: "Generating release notes"
           command: |
-            echo "### Supported Mattermost Server Versions: $(cat plugin.json | jq .min_server_version -r)+"  >> release-notes.md
+            echo "### Supported Mattermost Server Versions: $(cat plugin.json | jq .min_server_version -r)+ \n## Enhancements\n\n## Fixes\n"  >> release-notes.md
             if [[ $(git tag -l | wc -l) -eq 1 ]]; then
-              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> release-notes.md;
+              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md;
             else
-              git log --pretty=oneline --abbrev-commit --no-decorate --no-color tags/$(git describe --tags --abbrev=0)^..HEAD >> release-notes.md;
+              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..HEAD >> dist/release-notes.md;
             fi
-            mv release-notes.md dist
       - *save_cache
       - persist_to_workspace:
           root: dist

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -104,8 +104,16 @@ jobs:
       - checkout
       - *restore_cache
       - run: make dist
-      - run: 'echo "### Supported Mattermost Server Versions: $(cat plugin.json | jq .min_server_version -r)+"  >> release-notes.md'
-      - run: 'mv release-notes.md dist'
+      - run:
+          name: "Generating release notes"
+          command: |
+            echo "### Supported Mattermost Server Versions: $(cat plugin.json | jq .min_server_version -r)+"  >> release-notes.md
+            if [[ $(git tag -l | wc -l) -eq 1 ]]; then
+              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> release-notes.md;
+            else
+              git log --pretty=oneline --abbrev-commit --no-decorate --no-color tags/$(git describe --tags --abbrev=0)^..HEAD >> release-notes.md;
+            fi
+            mv release-notes.md dist
       - *save_cache
       - persist_to_workspace:
           root: dist

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -107,11 +107,11 @@ jobs:
       - run:
           name: "Generating release notes"
           command: |
-            echo "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n"  >> dist/release-notes.md
+            printf "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n"  >> dist/release-notes.md
             if [[ $(git tag -l | wc -l) -eq 1 ]]; then
-              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md
+              git log --pretty='format:- %h %s' --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md
             else
-              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..HEAD >> dist/release-notes.md
+              git log --pretty='format:- %h %s' --abbrev-commit --no-decorate --no-color $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..HEAD >> dist/release-notes.md
             fi
       - *save_cache
       - persist_to_workspace:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -104,11 +104,14 @@ jobs:
       - checkout
       - *restore_cache
       - run: make dist
+      - run: 'echo "### Supported Mattermost Server Versions: $(cat plugin.json | jq .min_server_version -r)+"  >> release-notes.md'
+      - run: 'mv release-notes.md dist'
       - *save_cache
       - persist_to_workspace:
           root: dist
           paths:
             - "*.tar.gz"
+            - "release-notes.md"
       - store_artifacts:
           path: dist
 
@@ -147,4 +150,4 @@ jobs:
       - run:
           name: "Publish Release on Github"
           command: |
-            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} -delete ${CIRCLE_TAG} dist/*.tar.gz
+            ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -b "$(< ./dist/release-notes.md)" -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} -delete ${CIRCLE_TAG} dist/*.tar.gz

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -107,7 +107,7 @@ jobs:
       - run:
           name: "Generating release notes"
           command: |
-            echo "### Supported Mattermost Server Versions: $(cat plugin.json | jq .min_server_version -r)+ \n## Enhancements\n\n## Fixes\n"  >> release-notes.md
+            echo "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n"  >> release-notes.md
             if [[ $(git tag -l | wc -l) -eq 1 ]]; then
               git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md;
             else

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -109,9 +109,9 @@ jobs:
           command: |
             echo "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n"  >> dist/release-notes.md
             if [[ $(git tag -l | wc -l) -eq 1 ]]; then
-              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md;
+              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md
             else
-              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..HEAD >> dist/release-notes.md;
+              git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..HEAD >> dist/release-notes.md
             fi
       - *save_cache
       - persist_to_workspace:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -107,7 +107,7 @@ jobs:
       - run:
           name: "Generating release notes"
           command: |
-            echo "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n"  >> release-notes.md
+            echo "Supported Mattermost Server Versions: **$(cat plugin.json | jq .min_server_version -r)+** \n## Enhancements\n\n## Fixes\n"  >> dist/release-notes.md
             if [[ $(git tag -l | wc -l) -eq 1 ]]; then
               git log --pretty=oneline --abbrev-commit --no-decorate --no-color $(git rev-list --max-parents=0 HEAD) HEAD >> dist/release-notes.md;
             else


### PR DESCRIPTION
#### Summary
A lot of logic is taken from [goreleaser](https://github.com/goreleaser/goreleaser/blob/master/internal/pipe/changelog/changelog.go) to generate the release notes. Please take note of special case when it is the first release. For first release a diffrent command is used to generate changelog as there isn't a previous tag to compare to. To understand the command please have a look [here](https://explainshell.com/explain?cmd=git+log+--pretty%3Doneline+--abbrev-commit+--no-decorate+--no-color+tags%2F%24%28git+describe+--tags+--abbrev%3D0%29%5E..HEAD) 

I have tested this orb (used personal [clone](https://circleci.com/orbs/registry/orb/rajatvaryani/plugin-ci))  by creating a sample plugin and checking the [release notes](https://github.com/RajatVaryani/sample-plugin/releases). This is how QA can test the story.  

This PR fixes [13587](https://github.com/mattermost/mattermost-server/issues/13587) and fixes [13586](https://github.com/mattermost/mattermost-server/issues/13586)

