### PR TITLE
Simplify git diff

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -79,8 +79,7 @@ jobs:
       - run:
           name: Check git diff
           command: |
-            git --no-pager diff go.mod go.sum
-            git --no-pager diff --quiet go.mod go.sum
+            git --no-pager diff --exit-code go.mod go.sum
       - *save_cache
 
   test:


### PR DESCRIPTION
Actually, `--quiet` implies `--exit-code` which is the real option we want here. Hence, this PR simplifies the code.