### PR TITLE
Automate publishing of orbs using circleci orbs-tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,17 +45,17 @@ workflows:
           source-dir: plugin-ci
       - orb-tools/publish-dev:
           context: matterbuild-circleci-token
-          orb-name: mattermost/plugin-ci
           publish-token-variable: CIRCLECI_TOKEN
+          orb-name: mattermost/plugin-ci
           requires: *orb_prep_jobs
-      - orb-tools/trigger-integration-tests-workflow: # todo add tests later
+      - orb-tools/trigger-integration-tests-workflow: # todo no tests currently
           context: matterbuild-circleci-token
           token-variable: CIRCLECI_TOKEN
           name: trigger-integration-dev
           requires:
             - orb-tools/publish-dev
 
-  plugin-ci_integration-tests: # set to false above todo add later
+  plugin-ci_integration-tests: # set to false above no tests currently
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       - integration-tests-for-your-orb
@@ -69,6 +69,8 @@ workflows:
           type: approval
           filters: *orb_promotion_filters
       - orb-tools/dev-promote-prod-from-git-tag:
+          context: matterbuild-circleci-token
+          publish-token-variable: CIRCLECI_TOKEN
           orb-name: mattermost/plugin-ci
           add-pr-comment: false
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,9 @@ workflows:
           orb-name: mattermost/plugin-ci
           publish-token-variable: CIRCLECI_TOKEN
           requires: *orb_prep_jobs
-      - orb-tools/trigger-integration-tests-workflow:
+      - orb-tools/trigger-integration-tests-workflow: # todo add tests later
+          context: matterbuild-circleci-token
+          token-variable: CIRCLECI_TOKEN
           name: trigger-integration-dev
           requires:
             - orb-tools/publish-dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,6 @@ workflows:
           source-dir: plugin-ci
       - orb-tools/publish-dev:
           context: matterbuild-circleci-token
-          orb-path: plugin-ci/orb.yml
           orb-name: mattermost/plugin-ci
           publish-token-variable: CIRCLECI_TOKEN
           requires: *orb_prep_jobs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,44 +1,75 @@
 version: 2.1
+
+orb_prep_jobs: &orb_prep_jobs
+  [
+    orb-tools/lint,
+    orb-tools/shellcheck,
+    orb-tools/pack
+  ]
+
+orb_promotion_filters: &orb_promotion_filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^(major|minor|patch)-release-v\d+\.\d+\.\d+$/
+
 orbs:
-  orb-tools: circleci/orb-tools@2
+  orb-tools: circleci/orb-tools@9.2
+  plugin-ci: mattermost/plugin-ci@<<pipeline.parameters.dev-orb-version>>
+
+parameters:
+  run-integration-tests:
+    type: boolean
+    default: false
+  dev-orb-version:
+    type: string
+    default: "dev:alpha"
+
+jobs:
+  integration-tests-for-your-orb:
+    executor: orb-tools/ubuntu
+    steps:
+      - checkout
+    # Test your orb e.g.
+    # - your-orb/your-orb-command
 
 workflows:
-  plugin-ci:
+  plugin-ci_lint_pack-validate_publish-dev:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/publish:
+      - orb-tools/lint:
+          lint-dir: plugin-ci
+      - orb-tools/shellcheck:
+          source-dir: plugin-ci
+      - orb-tools/pack:
+          source-dir: plugin-ci
+      - orb-tools/publish-dev:
           context: matterbuild-circleci-token
           orb-path: plugin-ci/orb.yml
-          orb-ref: mattermost/plugin-ci@dev:${CIRCLE_BRANCH}
-          publish-token-variable: "$CIRCLECI_TOKEN"
-          validate: true
-          filters:
-            branches:
-              ignore:
-                - master
-      - approve-increment:
+          orb-name: mattermost/plugin-ci
+          publish-token-variable: CIRCLECI_TOKEN
+          requires: *orb_prep_jobs
+      - orb-tools/trigger-integration-tests-workflow:
+          name: trigger-integration-dev
+          requires:
+            - orb-tools/publish-dev
+
+  plugin-ci_integration-tests: # set to false above todo add later
+    when: << pipeline.parameters.run-integration-tests >>
+    jobs:
+      - integration-tests-for-your-orb
+
+  # Trigger by running git tag patch-release-v0.0.1
+  # and then git push origin patch-release-v0.0.1
+  plugin-ci_tag-triggered-orb-publishing:
+    unless: << pipeline.parameters.run-integration-tests >>
+    jobs:
+      - hold-for-approval:
           type: approval
-          filters:
-            branches:
-              only: master
-      - orb-tools/increment:
-          context: matterbuild-circleci-token
-          orb-path: plugin-ci/orb.yml
-          orb-ref: "mattermost/plugin-ci"
-          segment: "patch"
-          publish-token-variable: "$CIRCLECI_TOKEN"
-          filters:
-            branches:
-              only:
-                - master
-          requires: [approve-increment]
-      - orb-tools/publish:
-          context: matterbuild-circleci-token
-          orb-path: plugin-ci/orb.yml
-          orb-ref: "mattermost/plugin-ci"
-          publish-token-variable: "$CIRCLECI_TOKEN"
-          validate: true
-          requires: [orb-tools/increment]
-          filters:
-            branches:
-              only:
-                - master
+          filters: *orb_promotion_filters
+      - orb-tools/dev-promote-prod-from-git-tag:
+          orb-name: mattermost/plugin-ci
+          add-pr-comment: false
+          requires:
+            - hold-for-approval
+          filters: *orb_promotion_filters

--- a/README.md
+++ b/README.md
@@ -3,3 +3,10 @@
 Orbs to help with building Mattermost repositories in circleci
 
 * [**plugin-ci**](https://circleci.com/orbs/registry/orb/mattermost/plugin-ci): shared jobs to add a plugin to the standard CI
+
+## Releasing new orb for plugin-ci
+```bash
+$ git tag patch-release-vX.Y.Z
+$ git push origin patch-release-vX.Y.Z
+```
+Manually approve in circleci


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->Before we didn't use the service bot to publish and promote circleci orbs. This now uses a service bot to promote dev orbs to production orbs. For the inconsistent naming of the CIRCLE_TOKENs please check the docs here: https://circleci.com/orbs/registry/orb/circleci/orb-tools

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->https://mattermost.atlassian.net/browse/IS-414

