### PR TITLE
Don't use cache for releases

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -112,9 +112,6 @@ jobs:
       - checkout
       - *restore_cache
       - run:
-          name: Verifying go dependencies cache
-          command: go mod verify
-      - run:
           name: Building Plugin Bundle
           command: make dist
       - run:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -112,6 +112,9 @@ jobs:
       - checkout
       - *restore_cache
       - run:
+          name: Verifying go dependencies cache
+          command: go mod verify
+      - run:
           name: Building Plugin Bundle
           command: make dist
       - run:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -110,7 +110,6 @@ jobs:
       name: default
     steps:
       - checkout
-      - *restore_cache
       - run:
           name: Building Plugin Bundle
           command: make dist
@@ -123,7 +122,6 @@ jobs:
             else
               git log --pretty='format:- %h %s' --abbrev-commit --no-decorate --no-color $(git describe --tags --abbrev=0 $(git describe --tags --abbrev=0)^)..HEAD >> dist/release-notes.md
             fi
-      - *save_cache
       - persist_to_workspace:
           root: dist
           paths:


### PR DESCRIPTION
#### Summary
Verify go dependencies cache before building a release

#### Ticket Link
https://community.mattermost.com/private-core/pl/e4x9kuwc47repeftekhxo5dhmw
