### PR TITLE
Change workflow for squash commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,14 +16,6 @@ parameters:
     type: string
     default: "dev:alpha"
 
-jobs:
-  integration-tests-for-your-orb:
-    executor: orb-tools/ubuntu
-    steps:
-      - checkout
-    # Test your orb e.g.
-    # - your-orb/your-orb-command
-
 workflows:
   plugin-ci_lint_pack-validate_publish-dev:
     jobs:
@@ -43,7 +35,6 @@ workflows:
   # e.g. git commit -am "[semver:patch] Final final fix version 2".
   plugin-ci_orb-publishing:
     jobs:
-      - integration-tests-for-your-orb # todo no tests currently
       - orb-tools/dev-promote-prod-from-commit-subject:
           context: matterbuild-circleci-token
           publish-token-variable: METANERD_ORB_PUBLISHER
@@ -51,8 +42,6 @@ workflows:
           add-pr-comment: false
           publish-version-tag: false
           fail-if-semver-not-indicated: false
-          requires:
-            - integration-tests-for-your-orb
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,9 +12,6 @@ orbs:
   plugin-ci: mattermost/plugin-ci@<<pipeline.parameters.dev-orb-version>>
 
 parameters:
-  run-integration-tests:
-    type: boolean
-    default: true
   dev-orb-version:
     type: string
     default: "dev:alpha"
@@ -29,7 +26,6 @@ jobs:
 
 workflows:
   plugin-ci_lint_pack-validate_publish-dev:
-    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/lint:
           lint-dir: plugin-ci
@@ -52,7 +48,6 @@ workflows:
   # publish semver by setting commit subject text "[semver:patch|minor|major|skip]"
   # e.g. git commit -am "[semver:patch] Final final fix version 2".
   plugin-ci_orb-publishing:
-    when: << pipeline.parameters.run-integration-tests >>
     jobs:
       - integration-tests-for-your-orb # todo no tests currently
       - orb-tools/dev-promote-prod-from-commit-subject:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,6 @@ workflows:
           publish-token-variable: METANERD_ORB_PUBLISHER
           orb-name: mattermost/plugin-ci
           requires: *orb_prep_jobs
-      - orb-tools/trigger-integration-tests-workflow: # todo no tests currently
-          context: matterbuild-circleci-token
-          token-variable: METANERD_ORB_PUBLISHER
-          name: trigger-integration-dev
-          requires:
-            - orb-tools/publish-dev
 
   # publish semver by setting commit subject text "[semver:patch|minor|major|skip]"
   # e.g. git commit -am "[semver:patch] Final final fix version 2".

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Orbs to help with building Mattermost repositories in circleci
 
 ## Releasing new orb for plugin-ci
 ```bash
-$ git tag patch-release-vX.Y.Z
-$ git push origin patch-release-vX.Y.Z
+$ git commit -am "[semver:patch] Change publishing workflow."
 ```
-Manually approve in circleci
+Options: `"[semver:patch|minor|major|skip]"`


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->This should allow for promoting squash committed dev orbs to be promoted to prod orbs. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

