### PR TITLE
Upgrade golangci-lint

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -30,7 +30,6 @@ commands:
     parameters:
       version:
         type: string
-        default: 1.31.0
       gobin:
         type: string
         default: /go/bin
@@ -66,12 +65,17 @@ aliases:
 
 jobs:
   lint:
+    parameters:
+      version:
+        default: 1.24.0
+        type: string
     executor:
       name: default
     resource_class: xlarge
     steps:
       - checkout
-      - install-golangci-lint
+      - install-golangci-lint:
+          version: << parameters.version >>
       - *restore_cache
       - run:
           name: Checking code style

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -30,7 +30,7 @@ commands:
     parameters:
       version:
         type: string
-        default: 1.24.0
+        default: 1.31.0
       gobin:
         type: string
         default: /go/bin

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -30,6 +30,7 @@ commands:
     parameters:
       version:
         type: string
+        default: 1.31.0
       gobin:
         type: string
         default: /go/bin
@@ -65,17 +66,12 @@ aliases:
 
 jobs:
   lint:
-    parameters:
-      version:
-        default: 1.24.0
-        type: string
     executor:
       name: default
     resource_class: xlarge
     steps:
       - checkout
-      - install-golangci-lint:
-          version: << parameters.version >>
+      - install-golangci-lint
       - *restore_cache
       - run:
           name: Checking code style


### PR DESCRIPTION
#### Summary
- 1.24.0 was failing while checking the incident response plugin, we had to stop using it: https://github.com/mattermost/mattermost-plugin-incident-response/pull/309
- 1.31.0 works

