### PR TITLE
Improve error message for go mod tidy check

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -80,7 +80,7 @@ jobs:
       - run:
           name: Check git diff
           command: |
-            git --no-pager diff --exit-code go.mod go.sum
+            git --no-pager diff --exit-code go.mod go.sum || (echo "Please run \"go mod tidy\" and commit the changes in go.mod and go.sum." && exit 1)
       - *save_cache
 
   test:


### PR DESCRIPTION
#### Summary
Community members seem to be confused why this check fails. This PR adds an message explaining the error.

#### Ticket Link
None

