### PR TITLE
Check if generated manifests are up to date

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -78,9 +78,14 @@ jobs:
           command: make check-style
       - run: go mod tidy -v
       - run:
-          name: Check git diff
+          name: Checking diff of go mod files
           command: |
             git --no-pager diff --exit-code go.mod go.sum || (echo "Please run \"go mod tidy\" and commit the changes in go.mod and go.sum." && exit 1)
+      - run: make apply
+      - run:
+          name: Checking diff of generated manifest files
+          command: |
+            git --no-pager diff --exit-code *manifest.* || (echo "Please run \"make apply\" and commit the changes in the generated manifests." && exit 1)
       - *save_cache
 
   test:


### PR DESCRIPTION
#### Summary
To prevent issues like https://github.com/mattermost/mattermost-plugin-github/pull/420 the circleci orb now checks if the generated manifests files are up to date.

Tested with https://github.com/mattermost/mattermost-plugin-github/commit/4ac1aaad9175d2ce3652a16fac23a9152fe99a36.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-32703
