### PR TITLE
Use npm loglevel verbose

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -68,6 +68,8 @@ jobs:
   lint:
     executor:
       name: default
+    env:
+      npm_config_loglevel=verbose
     resource_class: xlarge
     steps:
       - checkout
@@ -91,6 +93,8 @@ jobs:
   test:
     executor:
       name: default
+    env:
+      npm_config_loglevel=verbose
     steps:
       - checkout
       - *restore_cache
@@ -100,6 +104,8 @@ jobs:
   coverage:
     executor:
       name: default
+    env:
+      npm_config_loglevel=verbose
     steps:
       - checkout
       - *restore_cache
@@ -113,6 +119,8 @@ jobs:
   build:
     executor:
       name: default
+    env:
+      npm_config_loglevel=verbose
     steps:
       - checkout
       - run:
@@ -138,6 +146,8 @@ jobs:
   deploy-ci:
     docker:
       - image: circleci/python:2.7
+    env:
+      npm_config_loglevel=verbose
     steps:
       - attach_workspace:
           at: dist
@@ -149,6 +159,8 @@ jobs:
   deploy-release:
     docker:
       - image: circleci/python:2.7
+    env:
+      npm_config_loglevel=verbose
     steps:
       - attach_workspace:
           at: dist
@@ -164,6 +176,8 @@ jobs:
   deploy-release-github:
     docker:
       - image: cibuilds/github:0.13
+    env:
+      npm_config_loglevel=verbose
     steps:
       - attach_workspace:
           at: dist

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -68,7 +68,7 @@ jobs:
   lint:
     executor:
       name: default
-    env:
+    environment:
       npm_config_loglevel=verbose
     resource_class: xlarge
     steps:
@@ -93,7 +93,7 @@ jobs:
   test:
     executor:
       name: default
-    env:
+    environment:
       npm_config_loglevel=verbose
     steps:
       - checkout
@@ -104,7 +104,7 @@ jobs:
   coverage:
     executor:
       name: default
-    env:
+    environment:
       npm_config_loglevel=verbose
     steps:
       - checkout
@@ -119,7 +119,7 @@ jobs:
   build:
     executor:
       name: default
-    env:
+    environment:
       npm_config_loglevel=verbose
     steps:
       - checkout
@@ -146,7 +146,7 @@ jobs:
   deploy-ci:
     docker:
       - image: circleci/python:2.7
-    env:
+    environment:
       npm_config_loglevel=verbose
     steps:
       - attach_workspace:
@@ -159,7 +159,7 @@ jobs:
   deploy-release:
     docker:
       - image: circleci/python:2.7
-    env:
+    environment:
       npm_config_loglevel=verbose
     steps:
       - attach_workspace:
@@ -176,7 +176,7 @@ jobs:
   deploy-release-github:
     docker:
       - image: cibuilds/github:0.13
-    env:
+    environment:
       npm_config_loglevel=verbose
     steps:
       - attach_workspace:


### PR DESCRIPTION
#### Summary

Instead of adding `--verbose` to the `npm install` command in every plugin's `Makefile` which:

- Requires shotgun surgery of the different repos
- Makes the output verbose on local environments

This PR instead makes it so the output is automatically verbose, and only for circleci build environments.

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-44776