### PR TITLE
Configure git to use ssh rather than unsupported `git://` protocol

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -71,6 +71,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
+      - run: git config --global url."ssh://git@".insteadOf git://
       - install-golangci-lint
       - *restore_cache
       - run:
@@ -93,6 +94,7 @@ jobs:
       name: default
     steps:
       - checkout
+      - run: git config --global url."ssh://git@".insteadOf git://
       - *restore_cache
       - run: make test
       - *save_cache
@@ -102,6 +104,7 @@ jobs:
       name: default
     steps:
       - checkout
+      - run: git config --global url."ssh://git@".insteadOf git://
       - *restore_cache
       - run:
           name: Generating Coverage Results
@@ -115,6 +118,7 @@ jobs:
       name: default
     steps:
       - checkout
+      - run: git config --global url."ssh://git@".insteadOf git://
       - run:
           name: Building Plugin Bundle
           command: make dist

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -10,7 +10,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: circleci/golang:1.16.0
+      - image: circleci/golang:1.16.0-node
 
 commands:
   deploy:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -10,7 +10,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: circleci/golang:1.16.0-node
+      - image: circleci/golang:1.16.0
 
 commands:
   deploy:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -24,6 +24,10 @@ commands:
           from: << parameters.filename >>
           to: << parameters.bucket >>
           arguments: '--acl public-read --cache-control no-cache'
+  use-git-ssh:
+    description: Configure git to use ssh for dependencies that are fetched with git
+    steps:
+      - run: git config --global url."ssh://git@".insteadOf git://
 
   install-golangci-lint:
     description: Install golangci-lint
@@ -71,7 +75,7 @@ jobs:
     resource_class: xlarge
     steps:
       - checkout
-      - run: git config --global url."ssh://git@".insteadOf git://
+      - use-git-ssh
       - install-golangci-lint
       - *restore_cache
       - run:
@@ -94,7 +98,7 @@ jobs:
       name: default
     steps:
       - checkout
-      - run: git config --global url."ssh://git@".insteadOf git://
+      - use-git-ssh
       - *restore_cache
       - run: make test
       - *save_cache
@@ -104,7 +108,7 @@ jobs:
       name: default
     steps:
       - checkout
-      - run: git config --global url."ssh://git@".insteadOf git://
+      - use-git-ssh
       - *restore_cache
       - run:
           name: Generating Coverage Results
@@ -118,7 +122,7 @@ jobs:
       name: default
     steps:
       - checkout
-      - run: git config --global url."ssh://git@".insteadOf git://
+      - use-git-ssh
       - run:
           name: Building Plugin Bundle
           command: make dist


### PR DESCRIPTION
#### Summary

As an alternative to https://github.com/mattermost/circleci-orbs/pull/30, this PR makes it so git is configured in a way that sidesteps this issue https://github.com/npm/cli/issues/4896.

#### Ticket Link

