### PR TITLE
[MM-40754] Upgrade to cimg/go and allow .nvmrc to be used

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -10,7 +10,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: circleci/golang:1.16.0-node
+      - image: cimg/go:1.18-node
 
 commands:
   deploy:
@@ -24,19 +24,39 @@ commands:
           from: << parameters.filename >>
           to: << parameters.bucket >>
           arguments: '--acl public-read --cache-control no-cache'
+  install-node:
+    description: Install node
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
+    steps:
+      - run:
+          name: Install Node
+          command: |
+            set +e
+            wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
+            export NVM_DIR="$HOME/.nvm"
+            [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+            nvm install << parameters.node_version >>
+            nvm alias default << parameters.node_version >>
+
+            echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+            echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
 
   install-golangci-lint:
     description: Install golangci-lint
     parameters:
       version:
         type: string
-        default: 1.31.0
+        default: 1.46.2
       gobin:
         type: string
-        default: /go/bin
+        default: $GOPATH/bin
       prefix:
         type: string
-        default: v1
+        default: v2
         description: Prefix for cache key to store the binary.
     steps:
       - restore_cache:
@@ -57,21 +77,27 @@ commands:
 aliases:
 - &restore_cache
   restore_cache:
-    key: go-mod-v1-{{ checksum "go.sum" }}
+    key: go-mod-v2-{{ checksum "go.sum" }}
 - &save_cache
   save_cache:
-    key: go-mod-v1-{{ checksum "go.sum" }}
+    key: go-mod-v2-{{ checksum "go.sum" }}
     paths:
     - "/go/pkg/mod"
 
 jobs:
   lint:
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
     executor:
       name: default
     resource_class: xlarge
     steps:
       - checkout
       - install-golangci-lint
+      - install-node:
+          node_version: << parameters.node_version >>
       - *restore_cache
       - run:
           name: Checking code style
@@ -89,19 +115,31 @@ jobs:
       - *save_cache
 
   test:
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
     executor:
       name: default
     steps:
       - checkout
+      - install-node:
+          node_version: << parameters.node_version >>
       - *restore_cache
       - run: make test
       - *save_cache
 
   coverage:
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
     executor:
       name: default
     steps:
       - checkout
+      - install-node:
+          node_version: << parameters.node_version >>
       - *restore_cache
       - run:
           name: Generating Coverage Results
@@ -111,10 +149,16 @@ jobs:
         file: server/coverage.txt
 
   build:
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
     executor:
       name: default
     steps:
       - checkout
+      - install-node:
+          node_version: << parameters.node_version >>
       - run:
           name: Building Plugin Bundle
           command: make dist
@@ -136,8 +180,12 @@ jobs:
           path: dist
 
   deploy-ci:
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
     docker:
-      - image: circleci/python:2.7
+      - image: cimg/python:2.7
     steps:
       - attach_workspace:
           at: dist
@@ -147,8 +195,12 @@ jobs:
           bucket: "s3://mattermost-plugins-ci/ci/"
 
   deploy-release:
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
     docker:
-      - image: circleci/python:2.7
+      - image: cimg/python:2.7
     steps:
       - attach_workspace:
           at: dist
@@ -162,6 +214,10 @@ jobs:
           bucket: "s3://mattermost-plugins-ci/release/"
 
   deploy-release-github:
+    parameters:
+      node_version:
+        type: string
+        default: "13.14"
     docker:
       - image: cibuilds/github:0.13
     steps:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -35,7 +35,8 @@ commands:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-            nvm install || nvm install 13.14
+
+            nvm install || nvm install 13.14 # use `.nvmrc` if it exists, otherwise use 13.14
             nvm alias default $(node --version)
 
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -165,7 +165,7 @@ jobs:
 
   deploy-ci:
     docker:
-      - image: cimg/python:2.7
+      - image: cimg/python:3.10
     steps:
       - attach_workspace:
           at: dist
@@ -176,7 +176,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: cimg/python:2.7
+      - image: cimg/python:3.10
     steps:
       - attach_workspace:
           at: dist

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 description: |
-  Stuff to do CI for mattermost plugins
+  Stuff to do CI for mattermost plugins.
+  Note that if an `.nvmrc` file is present in the plugin project's root directory, this file will be used to determine what version of node to install for CI.
 
 orbs:
   aws-s3: circleci/aws-s3@1.0.16
@@ -10,7 +11,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: cimg/go:1.18-node
+      - image: cimg/go:1.19-node
 
 commands:
   deploy:
@@ -34,7 +35,6 @@ commands:
             wget -qO- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.1/install.sh | bash
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-            [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
             nvm install || nvm install 13.14
             nvm alias default $(node --version)
 
@@ -46,7 +46,7 @@ commands:
     parameters:
       version:
         type: string
-        default: 1.46.2
+        default: 1.49.0
       gobin:
         type: string
         default: $GOPATH/bin
@@ -78,7 +78,7 @@ aliases:
   save_cache:
     key: go-mod-v2-{{ checksum "go.sum" }}
     paths:
-    - "/go/pkg/mod"
+    - "$GOPATH/pkg/mod"
 
 jobs:
   lint:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -11,7 +11,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: cimg/go:1.19-node
+      - image: cimg/go:1.19
 
 commands:
   deploy:

--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -26,10 +26,6 @@ commands:
           arguments: '--acl public-read --cache-control no-cache'
   install-node:
     description: Install node
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     steps:
       - run:
           name: Install Node
@@ -39,8 +35,8 @@ commands:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-            nvm install << parameters.node_version >>
-            nvm alias default << parameters.node_version >>
+            nvm install || nvm install 13.14
+            nvm alias default $(node --version)
 
             echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
             echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
@@ -86,18 +82,13 @@ aliases:
 
 jobs:
   lint:
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     executor:
       name: default
     resource_class: xlarge
     steps:
       - checkout
       - install-golangci-lint
-      - install-node:
-          node_version: << parameters.node_version >>
+      - install-node
       - *restore_cache
       - run:
           name: Checking code style
@@ -115,31 +106,21 @@ jobs:
       - *save_cache
 
   test:
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     executor:
       name: default
     steps:
       - checkout
-      - install-node:
-          node_version: << parameters.node_version >>
+      - install-node
       - *restore_cache
       - run: make test
       - *save_cache
 
   coverage:
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     executor:
       name: default
     steps:
       - checkout
-      - install-node:
-          node_version: << parameters.node_version >>
+      - install-node
       - *restore_cache
       - run:
           name: Generating Coverage Results
@@ -149,16 +130,11 @@ jobs:
         file: server/coverage.txt
 
   build:
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     executor:
       name: default
     steps:
       - checkout
-      - install-node:
-          node_version: << parameters.node_version >>
+      - install-node
       - run:
           name: Building Plugin Bundle
           command: make dist
@@ -180,10 +156,6 @@ jobs:
           path: dist
 
   deploy-ci:
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     docker:
       - image: cimg/python:2.7
     steps:
@@ -195,10 +167,6 @@ jobs:
           bucket: "s3://mattermost-plugins-ci/ci/"
 
   deploy-release:
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     docker:
       - image: cimg/python:2.7
     steps:
@@ -214,10 +182,6 @@ jobs:
           bucket: "s3://mattermost-plugins-ci/release/"
 
   deploy-release-github:
-    parameters:
-      node_version:
-        type: string
-        default: "13.14"
     docker:
       - image: cibuilds/github:0.13
     steps:


### PR DESCRIPTION
#### Summary

This PR updates the `plugin-ci` orb to use Go 1.18, while also accepting a node version from the project's `.nvmrc` to use to install a specific version of node. If no file exists, it falls back to node `v13.14`

The PR is similar to https://github.com/mattermost/circleci-orbs/pull/29

#### Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-40754