### PR TITLE
Scale resource class for lint job down to large

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -88,7 +88,7 @@ jobs:
   lint:
     executor:
       name: default
-    resource_class: xlarge
+    resource_class: large
     steps:
       - checkout
       - use-git-ssh


### PR DESCRIPTION
The `resource_class` is not available in the CircleCI free plan. Given that this orb should allow plugin devs to easily run there CI it should work with the free tier.

The apps plugin [has been running `large`](https://github.com/mattermost/mattermost-plugin-apps/blob/b8285d143c218bb778bbb19fe0989119491d2064/.circleci/config.yml#L48
) without any problems for a while now. I think it's save to scale down.

Fixes https://github.com/mattermost/circleci-orbs/issues/33