### PR TITLE
Disable CGO for plugin builds

### DIFF
--- a/plugin-ci/orb.yml
+++ b/plugin-ci/orb.yml
@@ -145,7 +145,7 @@ jobs:
       - use-git-ssh
       - run:
           name: Building Plugin Bundle
-          command: make dist
+          command: env CGO_ENABLED=0 make dist
       - run:
           name: Generating Release Notes
           command: |


### PR DESCRIPTION
#### Summary

Similar to https://github.com/mattermost/mattermost-plugin-apps/pull/318, the CGO issue has come up with other plugin projects. This PR makes it so CGO is disabled for all plugin builds in CI, by setting `CGO_ENABLED=0` while calling `make dist`.

#### Ticket Link

Fixes https://github.com/mattermost/circleci-orbs/issues/36

